### PR TITLE
Fix FuzzyResultRecord toString typo

### DIFF
--- a/src/main/java/com/pe/text/FuzzyMatcherProvider.java
+++ b/src/main/java/com/pe/text/FuzzyMatcherProvider.java
@@ -30,7 +30,7 @@ public interface FuzzyMatcherProvider {
     FuzzyMatcher matcher(CharSequence text, int fromIndex, int toIndex);
 
     /**
-     * Creates {@link FuzzyMatcher} for the specified text, and start offset. Equivalent to the {@code paatern.matcher(text, fromIndex, text.length())}
+     * Creates {@link FuzzyMatcher} for the specified text, and start offset. Equivalent to the {@code pattern.matcher(text, fromIndex, text.length())}
      *
      * @param text      The text to scan.
      * @param fromIndex The start offset to scan.

--- a/src/main/java/com/pe/text/FuzzyResultRecord.java
+++ b/src/main/java/com/pe/text/FuzzyResultRecord.java
@@ -56,7 +56,7 @@ class FuzzyResultRecord implements FuzzyResult {
 
     @Override
     public String toString() {
-        return "FuzzyResul{" + pattern.toString() +
+        return "FuzzyResult{" + pattern.toString() +
                 ", start=" + start +
                 ", end=" + end +
                 ", distance=" + distance +

--- a/src/test/java/com/pe/text/FuzzyResultRecordTest.java
+++ b/src/test/java/com/pe/text/FuzzyResultRecordTest.java
@@ -1,0 +1,18 @@
+package com.pe.text;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FuzzyResultRecordTest {
+
+    @Test
+    void testToStringContainsClassName() {
+        FuzzyPattern pattern = FuzzyPattern.compile("test", 1);
+        FuzzyMatcher matcher = pattern.matcher("test");
+        assertTrue(matcher.find(), "Matching should be found");
+        FuzzyResultRecord record = new FuzzyResultRecord(matcher);
+        String str = record.toString();
+        assertTrue(str.startsWith("FuzzyResult{"), "toString should start with class name");
+    }
+}


### PR DESCRIPTION
## Summary
- fix typo in `FuzzyResultRecord.toString`
- correct JavaDoc of `FuzzyMatcherProvider.matcher`
- add unit test for `FuzzyResultRecord.toString`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*